### PR TITLE
Added Japanese and English test vectors

### DIFF
--- a/test/mnemonic/data/fixtures.json
+++ b/test/mnemonic/data/fixtures.json
@@ -143,12 +143,6 @@
        "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
        "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
        "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"
-     ],
-     [
-       "TREZOR",
-       "38fe1937dd2135d7ca5e472565c41ded449d8cea2e70e1c93571c21831c82f0f466c3d94f29bff1d0cce3e85a22b93364627af716ee91a477d6e2e55abf4e761",
-       "decline valid evil ripple battle typical city similar century comfort alter surround endorse shoe post sock tide endless fragile loud loan tomato rotate trip history uncover device dawn vault major decline spawn peasant frame snow middle kit reward roof cash electric twin merit prize satisfy inhale lyrics lucky",
-       "d9a9b65c54df4104349d5ce6f9275f249160ddf378deff6e540f5492e449e0378ee20b1622bef982f6dddb003568e449fee66335cb45cbe3f8a41050b251238a"
      ]
    ],
    "japanese": [

--- a/test/mnemonic/mnemonic.dart
+++ b/test/mnemonic/mnemonic.dart
@@ -1,5 +1,7 @@
 
+import 'dart:collection';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:dartsv/src/bip39/bip39.dart';
 import 'package:resource/resource.dart';
@@ -27,6 +29,30 @@ main(){
                 return 'spanish';
             default:
                 return 'english';
+        }
+    }
+
+
+    Wordlist getWordlist(String name) {
+        switch (name) {
+            case 'chinese_simplified':
+                return Wordlist.CHINESE_SIMPLIFIED;
+            case 'chinese_traditional':
+                return Wordlist.CHINESE_TRADITIONAL;
+            case 'english':
+                return Wordlist.ENGLISH;
+            case 'french':
+                return Wordlist.FRENCH;
+            case 'italian':
+                return Wordlist.ITALIAN;
+            case 'japanese':
+                return Wordlist.JAPANESE;
+            case 'korean':
+                return Wordlist.KOREAN;
+            case 'spanish':
+                return Wordlist.SPANISH;
+            default:
+                return Wordlist.ENGLISH;
         }
     }
 
@@ -178,6 +204,32 @@ main(){
         expect(seed.length, equals(512 / 8));
     });
 
+
+    test('it should pass test vectors ', () async {
+
+        await File("${Directory.current.path}/test/mnemonic/data/fixtures.json")
+            .readAsString()
+            .then((contents) => jsonDecode(contents))
+            .then((jsonData) async {
+                var hashMap = HashMap.from(jsonData);
+            await Future.forEach(hashMap.keys, (key) async {
+
+                var wordList = getWordlist(key);
+                Mnemonic mnemonic = Mnemonic(DEFAULT_WORDLIST: wordList);
+                for (List<dynamic> vector in hashMap[key])  {
+                    var code = vector[1] ;
+                    var phrase = vector[2] ;
+                    var seed = vector[3] ;
+                    var derivedSeed = mnemonic.toSeedHex(phrase, vector[0]);
+
+                    var isValid = await mnemonic.validateMnemonic(phrase);
+                    expect(isValid, isTrue);
+                    expect(derivedSeed, equals(seed));
+                }
+
+            });
+        });
+    });
 
 }
 


### PR DESCRIPTION
- Added tests for the Japanese and English test vectors.
NOTE: One of the english test vectors for 48-word mnemonics does not
work. It fails to validate as a valid mnemonic. Removing for now pending
a deep-dive.