### PR TITLE
Multisig Support

### DIFF
--- a/lib/src/transaction/default_builder.dart
+++ b/lib/src/transaction/default_builder.dart
@@ -45,10 +45,12 @@ mixin DefaultUnlockMixin on _DefaultUnlockBuilder implements UnlockingScriptBuil
 }
 
 abstract class _DefaultUnlockBuilder extends SignedUnlockBuilder implements UnlockingScriptBuilder{
-  SVSignature signature;
   SVScript _script = SVScript();
 
   _DefaultUnlockBuilder();
+
+  @override
+  List<SVSignature> signatures = <SVSignature>[];
 
   @override
   SVScript get scriptSig => getScriptSig();
@@ -64,5 +66,6 @@ abstract class _DefaultUnlockBuilder extends SignedUnlockBuilder implements Unlo
 
 class DefaultUnlockBuilder extends _DefaultUnlockBuilder with DefaultUnlockMixin{
   DefaultUnlockBuilder() : super();
+
 }
 

--- a/lib/src/transaction/p2ms_builder.dart
+++ b/lib/src/transaction/p2ms_builder.dart
@@ -1,0 +1,120 @@
+
+import 'package:dartsv/src/exceptions.dart';
+import 'package:dartsv/src/script/opcodes.dart';
+import 'package:dartsv/src/transaction/signed_unlock_builder.dart';
+import 'package:hex/hex.dart';
+import 'package:sprintf/sprintf.dart';
+
+import '../../dartsv.dart';
+
+
+/// ** P2PMS (multisig) locking Script (output script / scriptPubkey) ***
+mixin P2MSLockMixin on _P2MSLockBuilder implements LockingScriptBuilder {
+
+  @override
+  SVScript getScriptPubkey(){
+
+    if (publicKeys == null || requiredSigs == 0) return SVScript();
+
+    if (publicKeys.length > 15){
+      throw ScriptException("Too many public keys. P2MS limit is 15 public keys");
+    }
+
+    if (requiredSigs > publicKeys.length) {
+      throw ScriptException("You can't have more signatures than public keys");
+    }
+
+    if (sorting) {
+      publicKeys.sort((a, b) => a.toString().compareTo(b.toString())); //sort the keys by default
+    }
+    var pubKeyString = publicKeys.fold('', (prev, elem) => prev + sprintf(' %s 0x%s', [HEX.decode(elem.toHex()).length, elem.toHex()]));
+
+    var scriptString = sprintf('OP_%s %s OP_%s OP_CHECKMULTISIG', [requiredSigs, pubKeyString, publicKeys.length]);
+
+    //OP_3 <pubKey1> <pubKey2> <pubKey3> <pubKey4> <pubKey5> OP_5 OP_CHECKMULTISIG
+    return SVScript.fromString(scriptString);
+  }
+}
+
+abstract class _P2MSLockBuilder implements LockingScriptBuilder {
+
+  List<SVPublicKey> publicKeys;
+  int requiredSigs;
+  bool sorting;
+
+  _P2MSLockBuilder(this.publicKeys, this.requiredSigs, this.sorting);
+
+  @override
+  void fromScript(SVScript script) {
+
+    if (script != null && script.buffer != null) {
+      var chunkList = script.chunks;
+
+      if (chunkList[chunkList.length - 1].opcodenum != OpCodes.OP_CHECKMULTISIG){
+        throw ScriptException("Malformed multisig script. OP_CHECKMULTISIG is missing.");
+      }
+
+      var keyCount = chunkList[0].opcodenum - 80;
+
+      publicKeys = <SVPublicKey>[];
+      for (var i = 1; i < keyCount + 1; i++){
+        publicKeys.add(SVPublicKey.fromDER(chunkList[i].buf));
+      }
+
+      requiredSigs = chunkList[keyCount + 1].opcodenum - 80;
+
+    }else{
+      throw ScriptException("Invalid Script or Malformed Script.");
+    }
+
+}
+}
+
+class P2MSLockBuilder extends _P2MSLockBuilder with P2MSLockMixin {
+  P2MSLockBuilder(List<SVPublicKey> publicKeys, int requiredSigs, {sorting = true})
+      : super(publicKeys, requiredSigs, sorting);
+}
+
+
+/// ** P2MS (multisig) unlocking Script (scriptSig / Input script) ***
+mixin P2MSUnlockMixin on _P2MSUnlockBuilder implements UnlockingScriptBuilder{
+
+  @override
+  SVScript getScriptSig() {
+    //   OP_1 <sig1> <sig2> <sig4>
+    return SVScript();
+  }
+
+}
+
+abstract class _P2MSUnlockBuilder extends SignedUnlockBuilder implements UnlockingScriptBuilder {
+
+  @override
+  SVSignature signature;
+
+  _P2MSUnlockBuilder();
+
+  @override
+  void fromScript(SVScript script) {
+    if (script != null && script.buffer != null) {
+
+    }else{
+      throw ScriptException("Invalid Script or Malformed Script.");
+    }
+  }
+
+  SVScript get scriptSig => getScriptSig();
+}
+
+class P2MSUnlockBuilder extends _P2MSUnlockBuilder with P2MSUnlockMixin{
+
+  //Expect the Signature to be injected after the fact. Input Signing is a
+  //weird one.
+  P2MSUnlockBuilder() : super();
+
+}
+
+
+
+
+

--- a/lib/src/transaction/p2pk_builder.dart
+++ b/lib/src/transaction/p2pk_builder.dart
@@ -44,10 +44,10 @@ mixin P2PKUnlockMixin on _P2PKUnlockBuilder implements UnlockingScriptBuilder{
   @override
   SVScript getScriptSig() {
 
-    if (signature == null) return SVScript();
+    if (signatures.isEmpty) return SVScript();
 
-    var signatureSize = HEX.decode(signature.toTxFormat()).length;
-    var scriptString =sprintf("%s 0x%s", [signatureSize, signature.toTxFormat()]);
+    var signatureSize = HEX.decode(signatures[0].toTxFormat()).length;
+    var scriptString =sprintf("%s 0x%s", [signatureSize, signatures[0].toTxFormat()]);
 
     return SVScript.fromString(scriptString);
   }
@@ -55,9 +55,11 @@ mixin P2PKUnlockMixin on _P2PKUnlockBuilder implements UnlockingScriptBuilder{
 }
 
 abstract class _P2PKUnlockBuilder extends SignedUnlockBuilder implements UnlockingScriptBuilder{
-  SVSignature signature;
 
   _P2PKUnlockBuilder();
+
+  @override
+  List<SVSignature> signatures = <SVSignature>[];
 
   @override
   SVScript get scriptSig => getScriptSig();

--- a/lib/src/transaction/p2pkh_builder.dart
+++ b/lib/src/transaction/p2pkh_builder.dart
@@ -98,11 +98,11 @@ mixin P2PKHUnlockMixin on _P2PKHUnlockBuilder implements UnlockingScriptBuilder{
   @override
   SVScript getScriptSig() {
 
-    if (signature == null || signerPubkey == null) return SVScript();
+    if (signatures == null || signatures.isEmpty || signerPubkey == null) return SVScript();
 
     var pubKeySize = HEX.decode(signerPubkey.toString()).length;
-    var signatureSize = HEX.decode(signature.toTxFormat()).length;
-    var scriptString =sprintf("%s 0x%s %s 0x%s", [signatureSize, signature.toTxFormat(), pubKeySize, signerPubkey.toString()]);
+    var signatureSize = HEX.decode(signatures[0].toTxFormat()).length;
+    var scriptString =sprintf("%s 0x%s %s 0x%s", [signatureSize, signatures[0].toTxFormat(), pubKeySize, signerPubkey.toString()]);
 
     return SVScript.fromString(scriptString);
   }
@@ -113,7 +113,7 @@ abstract class _P2PKHUnlockBuilder extends SignedUnlockBuilder implements Unlock
   SVPublicKey signerPubkey;
 
   @override
-  SVSignature signature;
+  List<SVSignature> signatures = <SVSignature>[];
 
   //The signature *must* be injected later, because of the way SIGHASH works
   //Hence the contract enforced by SignedUnlockBuilder
@@ -141,7 +141,7 @@ abstract class _P2PKHUnlockBuilder extends SignedUnlockBuilder implements Unlock
       var pubKey = chunkList[1].buf;
 
       signerPubkey = SVPublicKey.fromHex(HEX.encode(pubKey));
-      signature = SVSignature.fromTxFormat(HEX.encode(sig));
+      signatures.add(SVSignature.fromTxFormat(HEX.encode(sig)));
 
     }else{
       throw ScriptException("Invalid Script or Malformed Script.");

--- a/lib/src/transaction/signed_unlock_builder.dart
+++ b/lib/src/transaction/signed_unlock_builder.dart
@@ -2,6 +2,6 @@
 import '../../dartsv.dart';
 
 abstract class SignedUnlockBuilder {
-  SVSignature get signature;
-  set signature(SVSignature value);
+  List<SVSignature> get signatures;
+  set signatures(List<SVSignature> value);
 }

--- a/lib/src/transaction/transaction.dart
+++ b/lib/src/transaction/transaction.dart
@@ -488,7 +488,7 @@ class Transaction{
         if (input.scriptBuilder is SignedUnlockBuilder) {
 
             //culminate in injecting the derived signature into the ScriptBuilder instance
-            (input.scriptBuilder as SignedUnlockBuilder).signature = sig;
+            (input.scriptBuilder as SignedUnlockBuilder).signatures.add(sig);
         }else{
             throw TransactionException("Trying to sign a Transaction Input that is missing a SignedUnlockBuilder");
         }

--- a/test/script/interpreter_test.dart
+++ b/test/script/interpreter_test.dart
@@ -156,10 +156,10 @@ void main() {
             var inputIndex = 0;
             print(HEX.encode(hash160(HEX.decode(publicKey.toString()))));
 
-            var signature = (tx.inputs[0].scriptBuilder as SignedUnlockBuilder).signature;
+            var signature = (tx.inputs[0].scriptBuilder as SignedUnlockBuilder).signatures[0];
 
             var scriptBuilder = P2PKHUnlockBuilder(publicKey);
-            scriptBuilder.signature = signature;
+            scriptBuilder.signatures.add(signature);
             var scriptSig = scriptBuilder.getScriptSig();
 
             var flags = ScriptFlags.SCRIPT_VERIFY_P2SH | ScriptFlags.SCRIPT_VERIFY_STRICTENC;

--- a/test/transaction/multisig_builder_test.dart
+++ b/test/transaction/multisig_builder_test.dart
@@ -1,69 +1,60 @@
 
-void main() {
+import 'package:dartsv/dartsv.dart';
+import 'package:dartsv/src/transaction/p2ms_builder.dart';
+import 'package:test/test.dart';
 
+void main() {
+  var pubKeyHexes = [
+    '022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da',
+    '03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9',
+    '021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18',
+    '02bf97f572a02a8900246d72c2e8fa3d3798a6e59c4e17de2d131d9c60d0d9b574',
+    '036a98a36aa7665874b1ba9130bc6d318e52fd3bdb5969532d7fc09bf2476ff842',
+    '033aafcbead78c08b0e0aacc1b0cdb40702a7c709b660bebd286e973242127e15b'
+  ];
+
+  var sortkeys = pubKeyHexes.getRange(0, 3).map((key) => SVPublicKey.fromHex(key));
+
+  group('P2MS (multisig) - Locking Script', (){
+    test('should create sorted script by default', () {
+      //var s = Script.buildMultisigOut(sortkeys, 2);
+      var lockBuilder = P2MSLockBuilder(sortkeys.toList(), 2);
+      var script = lockBuilder.getScriptPubkey();
+      expect( script.toString(), equals( 'OP_2 33 0x021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18 33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da 33 0x03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9 OP_3 OP_CHECKMULTISIG'));
+    });
+
+    test( 'should fail when number of required signatures is greater than number of pubkeys', () {
+      expect(sortkeys.length, equals(3));
+      var lockBuilder = P2MSLockBuilder(sortkeys.toList(), 4);
+      expect(() => lockBuilder.getScriptPubkey(), throwsException);
+    });
+
+    test('should create unsorted script if specified', () {
+      var lockBuilder = P2MSLockBuilder(sortkeys.toList(), 2);
+      var unsortedLockBuilder = P2MSLockBuilder(sortkeys.toList(), 2, sorting: false);
+      var sortedScript = lockBuilder.getScriptPubkey();
+      var unsortedScript = unsortedLockBuilder.getScriptPubkey();
+
+      expect(sortedScript.toString(), isNot(equals(unsortedScript.toString())));
+      expect(unsortedScript.toString(), equals( 'OP_2 33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da 33 0x03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9 33 0x021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18 OP_3 OP_CHECKMULTISIG'));
+    });
+
+    test('can recover state using fromScript', (){
+      var script = SVScript.fromString('OP_2 33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da 33 0x03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9 OP_2 OP_CHECKMULTISIG');
+
+      var lockBuilder = P2MSLockBuilder(null, null);
+      lockBuilder.fromScript(script);
+
+      expect(lockBuilder.publicKeys?.length, equals(2));
+      expect(lockBuilder.requiredSigs, equals(2));
+      expect(lockBuilder.publicKeys[0].toHex(), equals('022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da'));
+      expect(lockBuilder.publicKeys[1].toHex(), equals('03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9'));
+    });
+  });
 }
 /*
 
-  describe('#buildMultisigOut', function () {
-    var pubKeyHexes = [
-      '022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da',
-      '03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9',
-      '021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18',
-      '02bf97f572a02a8900246d72c2e8fa3d3798a6e59c4e17de2d131d9c60d0d9b574',
-      '036a98a36aa7665874b1ba9130bc6d318e52fd3bdb5969532d7fc09bf2476ff842',
-      '033aafcbead78c08b0e0aacc1b0cdb40702a7c709b660bebd286e973242127e15b'
-    ]
-    var sortkeys = pubKeyHexes.slice(0, 3).map(PublicKey)
-    it('should create sorted script by default', function () {
-      var s = Script.buildMultisigOut(sortkeys, 2)
-      s.toString().should.equal('OP_2 33 0x021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18 33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da 33 0x03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9 OP_3 OP_CHECKMULTISIG')
-      s.isMultisigOut().should.equal(true)
-    })
-    it('should fail when number of required signatures is greater than number of pubkeys', function () {
-      expect(sortkeys.length).to.equal(3)
-      expect(function () {
-        return Script.buildMultisigOut(sortkeys, 4)
-      }).to.throw('Number of required signatures must be less than or equal to the number of public keys')
-    })
-    it('should create unsorted script if specified', function () {
-      var s = Script.buildMultisigOut(sortkeys, 2)
-      var u = Script.buildMultisigOut(sortkeys, 2, {
-        noSorting: true
-      })
-      s.toString().should.not.equal(u.toString())
-      u.toString().should.equal('OP_2 33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da 33 0x03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9 33 0x021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18 OP_3 OP_CHECKMULTISIG')
-      s.isMultisigOut().should.equal(true)
-    })
-    var testMn = function (m, n) {
-      var pubkeys = pubKeyHexes.slice(0, n).map(PublicKey)
-      var s = Script.buildMultisigOut(pubkeys, m)
-      s.isMultisigOut().should.equal(true)
-    }
-    for (var n = 1; n < 6; n++) {
-      for (var m = 1; m <= n; m++) {
-        it('should create ' + m + '-of-' + n, testMn.bind(null, m, n))
-      }
-    }
-  })
 
-  describe('#isMultisigOut', function () {
-    it('should identify known multisig out 1', function () {
-      Script('OP_2 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 OP_2 OP_CHECKMULTISIG').isMultisigOut().should.equal(true)
-    })
-    it('should identify known multisig out 2', function () {
-      Script('OP_1 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 OP_2 OP_CHECKMULTISIG').isMultisigOut().should.equal(true)
-    })
-    it('should identify known multisig out 3', function () {
-      Script('OP_2 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 21 0x03363d90d447b00c9c99ceac05b6262ee053441c7e55552ffe526bad8f83ff4640 OP_3 OP_CHECKMULTISIG').isMultisigOut().should.equal(true)
-    })
-
-    it('should identify non-multisig out 1', function () {
-      Script('OP_2 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 21 0x038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508 OP_2 OP_CHECKMULTISIG OP_EQUAL').isMultisigOut().should.equal(false)
-    })
-    it('should identify non-multisig out 2', function () {
-      Script('OP_2').isMultisigOut().should.equal(false)
-    })
-  })
 
   describe('#isMultisigIn', function () {
     it('should identify multisig in 1', function () {

--- a/test/transaction/p2pkh_builder_test.dart
+++ b/test/transaction/p2pkh_builder_test.dart
@@ -43,10 +43,10 @@ void main() {
       var unlockBuilder = P2PKHUnlockBuilder(pubkey);
       unlockBuilder.fromScript(script);
 
-      expect(unlockBuilder.signature, isNotNull);
+      expect(unlockBuilder.signatures, isNotEmpty);
       expect(unlockBuilder.signerPubkey, isNotNull);
       expect(unlockBuilder.signerPubkey.toString(), equals(pubkey.toString()));
-      expect(unlockBuilder.signature.toString(), equals(signature.toString()));
+      expect(unlockBuilder.signatures[0].toString(), equals(signature.toString()));
 
     });
 


### PR DESCRIPTION
- The multisig builder support required a modification to the way
      Signatures are handled in the framework. Rather than expecting a
    signed unlockbuilder to have one signature, we now implicitly assumed
    that it is a list of signatures. This way we can specialize the use of
    add the signatures added via "Transaction.signInput()" inside the
    UnlockBuilder instance.

- Added tests for P2MS