### PR TITLE
P2PK Fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Stephan M. February
+Copyright (c) 2019-2020 Stephan M. February <stephan@werkswinkel.com>
 
 Copyright (c) 2018-2019 Yours Inc.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TwoStack WalletSDK is a Bitcoin library for the Dart Language \( [dartlang.org](https://dartlang.org) \), loosely based on the Moneybutton/BSV Javascript library. This library has been built in line with the ideals espoused by BitcoinSV, i.e. massive on-chain scaling, protocol stability and original-bitcoin-protocol implementation.
+TwoStack WalletSDK is a Bitcoin library for the Dart Language \( [dartlang.org](https://dartlang.org) \), loosely based on the [Moneybutton/BSV](https://github.com/moneybutton/bsv) Javascript library. This library has been built in line with the ideals espoused by BitcoinSV, i.e. massive on-chain scaling, protocol stability and original-bitcoin-protocol implementation.
 
 This library therefore lacks , and will not implement :
 * Segregated Witness \(Segwit\) Transaction support
@@ -10,16 +10,16 @@ This library therefore lacks , and will not implement :
 * Check Datasig \(OP\_CHECKDATASIG\) 
 
 Current Supported features are :
-* P2PKH Transactions \(building and spending from\)
+* P2PKH Transactions 
 * P2SH Transactions 
 * P2MS Transactions (naked multisig)
 * P2PK Transactions
-* Custom Transaction Builder Interface
+* Custom-Script Builder Interface to support novel locking/spending conditions within Script
 * Data-only Transactions
 * HD Key Derivation \(BIP32\)
 * Original Bitcoin Address format 
 * Bitcoin Signed Messages
-* Bip39 Mnemonic Support (BIP39)
+* Mnemonic Seed Support (BIP39)
 * A built-in Bitcoin Script Interpreter
 
 #### Sample of the Transaction API:
@@ -39,7 +39,7 @@ Current Supported features are :
 
 ### Installation
 
-This library was built using version \(2.3.1\) of the Dart SDK [https://dart.dev/tools/sdk](https://dart.dev/tools/sdk), but should work with _Dart SDK 2.1.x_ onwards.  
+This library was built using version \(2.8.2\) of the Dart SDK [https://dart.dev/tools/sdk](https://dart.dev/tools/sdk), but should work with _Dart SDK 2.1.x_ onwards.  
 Therefore, as a pre-requisite ensure that you have at least that version of the Dart SDK installed before proceeding.
 
 Navigate to the root folder of this project, and pull the required supported Dart libraries using the `pub` package manager.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,11 +1,11 @@
 name: cli_example
 description: DartSV CLI Demo Application
-version: 0.1.0
+version: 0.3.0
 homepage: https://github.com/twostack/cli-example
 author: Stephan M. February <stephan@werkswinkel.com>
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.8.0 <3.0.0'
 
 dependencies:
   hex: ^0.1.2
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.14.11
   sprintf: ^4.0.2
   http: ^0.12.0+2
-  dartsv: ^0.2.4-RC1
+  dartsv: 0.3.0
   bip39: ^1.0.3
 
 

--- a/lib/src/transaction/p2pk_builder.dart
+++ b/lib/src/transaction/p2pk_builder.dart
@@ -1,4 +1,5 @@
 
+import 'package:dartsv/src/exceptions.dart';
 import 'package:dartsv/src/transaction/signed_unlock_builder.dart';
 import 'package:hex/hex.dart';
 import 'package:sprintf/sprintf.dart';
@@ -24,12 +25,24 @@ abstract class _P2PKLockBuilder implements LockingScriptBuilder{
 
   _P2PKLockBuilder(this.signerPubkey);
 
-  @override
-  SVScript get scriptPubkey => getScriptPubkey();
+  //SVScript get scriptPubkey => getScriptPubkey();
 
   @override
   void fromScript(SVScript script) {
-    throw UnimplementedError();
+
+    if (script != null && script.buffer != null) {
+
+      var chunkList = script.chunks;
+
+      if (chunkList.length != 2){
+        throw ScriptException("Wrong number of data elements for P2PK ScriptPubkey");
+      }
+
+      signerPubkey = SVPublicKey.fromDER(chunkList[0].buf);
+
+    }else{
+      throw ScriptException("Invalid Script or Malformed Script.");
+    }
   }
 
 }

--- a/lib/src/transaction/signed_unlock_builder.dart
+++ b/lib/src/transaction/signed_unlock_builder.dart
@@ -1,7 +1,31 @@
 
 import '../../dartsv.dart';
 
+/// All unlocking scripts that will use OP_CHECKSIG or OP_CHECKMULTISIG operations
+/// must implement this interface. Implementing this interface will signal to
+/// the framework that the unlocking script (scriptSig) will participate in
+/// the process of generating signatures for the [Transaction]'s Input Script.
+///
+/// This interface will *always* need to be implemented alongside the
+/// [UnlockingScriptBuilder] interface.
+///
+/// After composing the [Transaction], when the developer calls the
+/// Transaction.signInput() method, the framework will inject the resultant
+/// signature into the [signatures] property of the
+/// [SignedUnlockBuilder] instance. This will allow the developer to use these
+/// signatures in generating the appropriate Input Script when the subclasses'
+/// [UnlockingScriptBuilder.getScriptSig()] method is called by either the
+/// framework, or explicitly by the developer themselves.
+///
 abstract class SignedUnlockBuilder {
+
+  /// The [signatures] property defines a list of signatures injected by
+  /// the framework whenever the Transaction.signInput() method is called.
+  /// Multiple sequential calls to Transaction.signInput() will cause
+  /// additional signatures to be added to this list.
+  ///
   List<SVSignature> get signatures;
+
+
   set signatures(List<SVSignature> value);
 }

--- a/lib/src/transaction/transaction.dart
+++ b/lib/src/transaction/transaction.dart
@@ -198,7 +198,7 @@ class Transaction{
     /// Constructs a  transaction instance from the raw hexadecimal string.
     Transaction.fromHex(String txnHex) {
 
-        List<int> hash = sha256Twice(HEX.decode(txnHex));
+        List<int> hash = sha256Twice(HEX.decode(txnHex)).reversed.toList();
         _txHash = hash;
         _txId = HEX.encode(_txHash);
         _parseTransactionHex(txnHex);
@@ -301,7 +301,7 @@ class Transaction{
         scriptBuilder ??= P2PKHLockBuilder(recipient);
 
         var txnOutput = TransactionOutput(scriptBuilder: scriptBuilder);
-        txnOutput.recipient = recipient;
+//        txnOutput.recipient = recipient;
         txnOutput.satoshis = sats;
 //        txnOutput.script = scriptBuilder.getScriptPubkey();
 
@@ -661,17 +661,17 @@ class Transaction{
                 }
             }
         }
-        return '';
+        return ''; //FIXME: Return a boolean value like a real programmer FFS !
     }
 
 
 
 
-    TransactionOutput getChangeOutput() {
+    TransactionOutput getChangeOutput(LockingScriptBuilder changeBuilder) {
         var outputs = _txnOutputs.where((elem) => elem.isChangeOutput);
 
         if (outputs.isEmpty) {
-            var out = TransactionOutput();
+            var out = TransactionOutput(scriptBuilder: changeBuilder);
             out.isChangeOutput = true;
 //            _txnOutputs.add(out);
             return out;
@@ -836,13 +836,12 @@ class Transaction{
 
         if (_nonChangeRecipientTotals() == _inputTotals()) return;
 
-        var txnOutput = getChangeOutput();
+        var txnOutput = getChangeOutput(_changeScriptBuilder);
 
         var changeAmount = _recalculateChange();
 
         //can't spend negative amount of change :/
         if (changeAmount > BigInt.zero) {
-            txnOutput.recipient = _changeAddress;
             txnOutput.satoshis = changeAmount;
             txnOutput.script = _changeScriptBuilder.getScriptPubkey();
             txnOutput.isChangeOutput = true;

--- a/lib/src/transaction/transaction_output.dart
+++ b/lib/src/transaction/transaction_output.dart
@@ -21,7 +21,6 @@ import 'package:sprintf/sprintf.dart';
 /// in February 2020.
 ///
 class TransactionOutput {
-    Address _recipient;
     BigInt _satoshis = BigInt.zero;
     String _transactionId;
     int _outputIndex;
@@ -118,18 +117,6 @@ class TransactionOutput {
     /// Sets the output script to the provided value
     set script(SVScript script) {
         _scriptBuilder.fromScript(script);
-    }
-
-    /// Returns the [Address] of the recipient in the case of a
-    /// P2PKH output. This is only useful for generating "change outputs".
-    Address get recipient => _recipient;
-
-    /// Sets the [Address] of the recipient in the case of a
-    /// P2PKH output. This is only useful for generating "change outputs".
-    /// Implicitly creates a P2PKH output script
-    set recipient(Address address) {
-        _scriptBuilder = P2PKHLockBuilder(address); //reset the scriptBuilder
-        _recipient = address;
     }
 
     /// Returns the number of satoshis the output is sending

--- a/test/transaction/p2pk_builder_test.dart
+++ b/test/transaction/p2pk_builder_test.dart
@@ -1,6 +1,10 @@
 
+import 'package:dartsv/src/address.dart';
+import 'package:dartsv/src/privatekey.dart';
 import 'package:dartsv/src/publickey.dart';
+import 'package:dartsv/src/sighash.dart';
 import 'package:dartsv/src/transaction/p2pk_builder.dart';
+import 'package:dartsv/src/transaction/transaction.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -11,6 +15,34 @@ void main() {
       var script = lockBuilder.getScriptPubkey();
       expect(script, isNotNull);
       expect(script.toString(), equals('33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da OP_CHECKSIG'));
+    });
+
+    test('', (){
+      var coinbaseOutput = "02000000016b748661a108dc35d8868a9a552b9364c6ee3f06a4604f722882d49cdc4d13020000000048473044022073062451397fb5e7e2e02f1603e2a92677d516a5e747b1ae2ad0996387916d4302200ae2ec97d4525621cef07f75f0b92b5e83341761fa604c83daf0390a76d5024241feffffff0200e1f505000000001976a91494837d2d5d6106aa97db38957dcc294181ee91e988ac00021024010000001976a9144d991c88b4fd954ea62aa7182d3b3e251896a83188acd5000000";
+      var privateKey = SVPrivateKey.fromWIF("cVVvUsNHhbrgd7aW3gnuGo2qJM45LhHhTCVXrDSJDDcNGE6qmyCs");
+      var changeAddress = Address("mu4DpTaD75nheE4z5CQazqm1ivej1vzL4L"); // my address
+      var recipientAddress = Address("n3aZKucfWmXeXhX13MREQQnqNfbrWiYKtg"); //bitcoin-cli address
+
+      //Create a Transaction instance from the RAW transaction data create by bitcoin-cli.
+      //this transaction contains the UTXO we are interested in
+      var txWithUTXO = Transaction.fromHex(coinbaseOutput);
+
+      //Let's create the set of Spending Transaction Inputs. These Transaction Inputs need to refer to the Outputs in
+      //the Transaction we are spending from.
+      var utxo = txWithUTXO.outputs[0]; //looking at the decoded JSON we can see that our UTXO in at vout[0]
+      var pubkey = SVPublicKey.fromHex('022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da');
+      var lockBuilder = P2PKLockBuilder(pubkey);
+
+      var locker = P2PKLockBuilder(pubkey);
+      var unlocker = P2PKUnlockBuilder();
+      var txn = Transaction();
+      txn.spendFromOutput(utxo, Transaction.NLOCKTIME_MAX_VALUE, scriptBuilder: unlocker) //set global sequenceNumber/nLocktime time for each Input created
+          .spendTo(recipientAddress, BigInt.from(50000000),scriptBuilder: locker) //spend half of a bitcoin (we should have 1 in the UTXO)
+          .sendChangeTo(changeAddress,scriptBuilder: locker) // spend change to myself
+          .withFeePerKb(100000);
+
+      //Sign the Transaction Input
+      txn.signInput(0, privateKey, sighashType: SighashType.SIGHASH_ALL | SighashType.SIGHASH_FORKID);
     });
   });
 }

--- a/test/transaction/transaction_test.dart
+++ b/test/transaction/transaction_test.dart
@@ -184,11 +184,15 @@ main() {
         expect(transaction.outputs.length, equals(2));
         expect(transaction.outputs[1].satoshis, equals(BigInt.from(472899)));
         expect(transaction.outputs[1].script.toString(), equals(P2PKHLockBuilder(changeAddress).getScriptPubkey().toString()));
+        var changeLocker = P2PKHLockBuilder(changeAddress);
+
+        //FIXME: I'm not entirely certain this test is valuable. We are baiscally
+        //passing in a changeLocker, and checking if it was correctly passed
         var actual = transaction
-            .getChangeOutput()
+            .getChangeOutput(changeLocker)
             .script
             .toString();
-        var expected = P2PKHLockBuilder(changeAddress).getScriptPubkey().toString();
+        var expected = changeLocker.getScriptPubkey().toString();
         expect(actual, equals(expected));
     });
 
@@ -308,8 +312,9 @@ main() {
 //            .signWith(privateKey);
         transaction.signInput( 0, privateKey);
 
+        var changeLocker = P2PKHLockBuilder(changeAddress);
         expect(transaction
-            .getChangeOutput()
+            .getChangeOutput(changeLocker)
             .satoshis, equals(BigInt.from(50000)));
 
         transaction = transaction
@@ -319,7 +324,7 @@ main() {
 
         expect(transaction.outputs.length, equals(3));
         expect(transaction.outputs[2].satoshis, equals(BigInt.from(30000)));
-        expect(transaction.outputs[2].script.toString(), equals(P2PKHLockBuilder(changeAddress).getScriptPubkey().toString()));
+        expect(transaction.outputs[2].script.toString(), equals(changeLocker.getScriptPubkey().toString()));
     });
 
 


### PR DESCRIPTION
- Fixes to the general framework to finally remove the default spending
  to P2PKH.
- Fix to Transaction.fromHex() which resulted in incorrect internal
  TransactionID, which resulted in a bad spending TX
- Fixed P2PK spending
- Removed redundant code from TransactionInput related to old way of
  creating locking scripts