### PR TITLE
Release prep - 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.1
+New Feature
+- Added DataLockBuilder to allow composing a simple data output script
+
+Bug Fixes
+- Bug fix submited by chen610620 for index bug on signing Transaction Inputs. The bug prevented signing of inputs other than the first one. 
+
 ## 0.3.0
 This represents a rather major refactor of the way in which the Script Builder   
 interface works. I have completely decoupled the creation of Custom Scripts   
@@ -10,7 +17,7 @@ of the SDK, and contains breaking changes. Please see below.
 - P2PKHUnlockBuilder, P2PKHLockBuilder
 - P2MSUnlockBuilder, P2MSLockBuilder
 - P2SHUnlockBuilder, P2SHLockBuilder
--P2PKLockBuilder, P2PKUnlockBuilder
+- P2PKLockBuilder, P2PKUnlockBuilder
 - Deep refactor of the way that TransactionInput processes scriptSig
 - Bugfix related to script serialization
 - New API on SVScript to parse and serialize to ASM format

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartsv
 description: Dart Library for interacting with the Bitcoin network. This library is especially well-suited for use in developing Flutter applications.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/twostack/dartsv
 
 environment:


### PR DESCRIPTION
- This release fixes an indexing bug which prevented signing of Inputs
  other than the first one.
- New feature of a DataLockBuilder that composes a simple Data Output
  using "OP_FALSE OP_RETURN <datablock>"