### PR TITLE
Fixed Script Behavior bug

### DIFF
--- a/lib/src/script/svscript.dart
+++ b/lib/src/script/svscript.dart
@@ -241,6 +241,7 @@ class SVScript with ScriptBuilder {
                     bw.write(chunk.buf);
                 }
             }
+
         }
 
         _byteArray = bw.toBytes();
@@ -368,6 +369,7 @@ class SVScript with ScriptBuilder {
 
     /// Renders this script in it's hexadecimal form as a String
     String toHex() {
+        _convertChunksToByteArray();
         return HEX.encode(_byteArray);
     }
 
@@ -580,6 +582,7 @@ class SVScript with ScriptBuilder {
 
 
     void _addBuffer(List<int> buf, prepend) {
+
         var opcodenum;
         var len = buf.length;
         if (len >= 0 && len < OpCodes.OP_PUSHDATA1) {

--- a/test/script/interpreter_test.dart
+++ b/test/script/interpreter_test.dart
@@ -645,7 +645,7 @@ void main() {
         test('Empty buffer should have value 0x00 in script', () {
             var s = SVScript().add(<int>[]);
             // script does not render anything so it appears invisible
-            expect(s.toHex(), equals(''));
+            expect(s.toHex(), equals('00'));
             // yet there is a script chunk there
             expect(s.chunks.length, equals(1));
             expect(s.chunks[0].opcodenum, equals(0));

--- a/test/script/svscript_test.dart
+++ b/test/script/svscript_test.dart
@@ -380,6 +380,13 @@ main() {
     });
   });
 
+    test('should add to existing script', (){
+      var buf = Uint8List(1);
+      var script = SVScript.fromString('OP_FALSE');
+      expect(script.add(buf).toString(), equals('OP_0 1 0x00'));
+      expect(script.add(buf).toHex(), equals('0001000100'));
+    });
+
     test('should add these push data', () {
       var buf = Uint8List(1);
       expect(SVScript().add(buf).toString(), equals('1 0x00'));


### PR DESCRIPTION
- When using "add()" to update the SVScript() instance's contents
  the toHex() function failed to serialize the additional contents.