### PR TITLE
Add a generic LockBuilder for Data

### DIFF
--- a/test/transaction/transaction_test.dart
+++ b/test/transaction/transaction_test.dart
@@ -173,6 +173,7 @@ main() {
       //Sign the Transaction Input
       txn.signInput(0, privateKey, sighashType: SighashType.SIGHASH_ALL | SighashType.SIGHASH_FORKID);
 
+      //FIXME: Where's the assertion ?
 
     });
     test('can calculate output amounts and correct change address', () {


### PR DESCRIPTION
- Add a generic locking script builder for data-only transaction outputs
  which will have zero satoshis.