### PR TITLE
Fixed Signed Message bug

### DIFF
--- a/lib/src/signature.dart
+++ b/lib/src/signature.dart
@@ -10,6 +10,7 @@ import 'package:pointycastle/macs/hmac.dart';
 import 'package:pointycastle/signers/ecdsa_signer.dart';
 import 'package:pointycastle/pointycastle.dart';
 import 'package:hex/hex.dart';
+import 'package:sprintf/sprintf.dart';
 
 import 'exceptions.dart';
 
@@ -152,7 +153,11 @@ class SVSignature {
         }
 
         var b1 = [val];
-        var b2 = HEX.decode(_r.toRadixString(16));
+
+        //This is a hack around the problem of having r-values of length 31. This causes invalid sigs
+        //see: https://github.com/twostack/dartsv/issues/35
+        var b2Padded= sprintf("%064s", [_r.toRadixString(16)]).replaceAll(' ', '0');
+        var b2 = HEX.decode(b2Padded);
         var b3 = HEX.decode(_s.toRadixString(16));
         return b1 + b2 + b3;
     }

--- a/test/message/message_test.dart
+++ b/test/message/message_test.dart
@@ -42,6 +42,21 @@ main() {
         expect(messageBuf.verifyFromAddress(addr, signatureBuffer1), isTrue);
     });
 
+    test('Signature get padded r-value to produce correct length', (){
+
+        String message = '/ipfs/QmdwwGaAujZ2gkPPAfQZJ9jUKRBB7d67ttD6phwU8BmfGS';
+        String wifKey = 'L4TAY9FYkGzwnZ77WRXZzYXsViKjVN31LzNenYfLLrEiFxoZbmSn';
+
+        SVPrivateKey privateKey = SVPrivateKey.fromWIF(wifKey);
+        Message messageSigner = Message(utf8.encode(message));
+        String signature = messageSigner.sign(privateKey);
+
+        var signatureLength = base64Decode(signature).length;
+
+        expect(signatureLength, equals(65));
+        expect(messageSigner.verifyFromPublicKey(privateKey.publicKey, signature), isTrue);
+    });
+
 
     test('can sign a message (buffer representation of arbitrary data)', () {
         Message messageBuf = new Message(base64Decode(bufferData));


### PR DESCRIPTION
- Under some conditions certain messages produce a signature with a 62-byte r-value. This causes signature verification to fail. This fix pads r-values to 64-byte length with leading zeros.