### PR TITLE
Fixed Databuilder scriptPubKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2
+- Bugfix: DataBuilder has script construction error for PUSHDATA transactions. 
+
 ## 0.4.1
 - Bugfix: Bitcoin-Signed-Messages sometimes generate Signatures with short r-values of only 62 bytes length. This causes compact signatures to fail verification. This is now fixed. 
 

--- a/lib/src/transaction/data_builder.dart
+++ b/lib/src/transaction/data_builder.dart
@@ -45,7 +45,7 @@ mixin DataLockMixin on _DataLockBuilder implements LockingScriptBuilder {
         if (len < OpCodes.OP_PUSHDATA1) {
           scriptPubkey = scriptPubkey + sprintf(' %s 0x%s', [len, encodedData]);
         } else {
-          scriptPubkey = scriptPubkey + sprintf(' %s %s 0x%s', [opcodenum, len, encodedData]);
+          scriptPubkey = scriptPubkey + sprintf(' %s %s 0x%s', [OpCodes.fromNum(opcodenum), len, encodedData]);
         }
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartsv
 description: Dart Library for interacting with the Bitcoin network. This library is especially well-suited for use in developing Flutter applications.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/twostack/dartsv
 
 environment:

--- a/test/transaction/data_builder_test.dart
+++ b/test/transaction/data_builder_test.dart
@@ -18,6 +18,13 @@ void main() {
       expect(lockBuilder.getScriptPubkey().toString(), equals('OP_0 OP_RETURN'));
     });
 
+    test('can handle larger data pushes', (){
+      var data = "3046022100bb3c194a30e460d81d34be0a230179c043a656f67e3c5c8bf47eceae7c4042ee0221008bf54ca11b2985285be0fd7a212873d243e6e73f5fad57e8eb14c4f39728b8c601";
+
+      var lockBuilder = DataLockBuilder(utf8.encode(data));
+      expect(() => lockBuilder.getScriptPubkey(), returnsNormally);
+    });
+
 
     test('fails if old-style OP_RETURN', () {
       var lockBuilder = DataLockBuilder(null);


### PR DESCRIPTION
- When creating larger scripts the default DataBuilder created
  an invalid pubkeyScript that fails internal checks when building
  the transaction.