### PR TITLE
Padding s-values to prevent invalid signatures

### DIFF
--- a/lib/src/signature.dart
+++ b/lib/src/signature.dart
@@ -154,11 +154,12 @@ class SVSignature {
 
         var b1 = [val];
 
-        //This is a hack around the problem of having r-values of length 31. This causes invalid sigs
+        //This is a hack around the problem of having r-values or s-values of length 31. This causes invalid sigs
         //see: https://github.com/twostack/dartsv/issues/35
         var b2Padded= sprintf("%064s", [_r.toRadixString(16)]).replaceAll(' ', '0');
         var b2 = HEX.decode(b2Padded);
-        var b3 = HEX.decode(_s.toRadixString(16));
+        var b3Padded= sprintf("%064s", [_s.toRadixString(16)]).replaceAll(' ', '0');
+        var b3 = HEX.decode(b3Padded);
         return b1 + b2 + b3;
     }
 

--- a/test/message/message_test.dart
+++ b/test/message/message_test.dart
@@ -57,6 +57,35 @@ main() {
         expect(messageSigner.verifyFromPublicKey(privateKey.publicKey, signature), isTrue);
     });
 
+    test('Signature with messages that are known to produce bad s-values', (){
+        String wifKey = 'KyAfciPXnXgy4Ao3BrTfW6A8BErr5xN846S7cCqoFNbbeGVmc3Sn';
+        SVPrivateKey privateKey = SVPrivateKey.fromWIF(wifKey);
+
+        var badMessages = <String>[
+            'rnyxGweL7ZXCkJlBp1Lk',
+            're73QPHgNV0L1aULrIje',
+            'BGWbnBocGTUxzaAf6B2E',
+            '7pNAWvS9J6O6crIK4m2j',
+            'yVlKCLHv0DD5FE8EOGMG',
+            'RonPIcSXc6gO6fpISDhb',
+            '83o3HReuc1eN7LXfxXcV',
+            'rt4tUatPi2MhPrrrB6QU',
+        ];
+
+        for(var i=0; i<badMessages.length; i++){
+
+            String message = badMessages[i];
+            Message messageSigner = Message(Utf8Codec().encode(message));
+            String signature = messageSigner.sign(privateKey);
+
+            var signatureLength = base64Decode(signature).length;
+
+            expect(signatureLength, equals(65));
+            expect(messageSigner.verifyFromPublicKey(privateKey.publicKey, signature), isTrue);
+        }
+
+    });
+
 
     test('can sign a message (buffer representation of arbitrary data)', () {
         Message messageBuf = new Message(base64Decode(bufferData));


### PR DESCRIPTION
The same problem that can happen with r-values of length 31 can also happen to the s-values and produce invalid signatures

see: https://github.com/twostack/dartsv/issues/35