### PR TITLE
Add Javascript target support

### DIFF
--- a/lib/src/encoding/utils.dart
+++ b/lib/src/encoding/utils.dart
@@ -103,7 +103,7 @@ Uint8List varIntWriter(int? length) {
         return writer.toBytes();
     }
 
-    if (length < 0xFFFFFFFFFFFFFFFF) {
+    if (BigInt.parse("0xFFFFFFFFFFFFFFFF").compareTo(BigInt.from(length)) == -1) {
 //            return HEX.decode("FF" + length.toRadixString(16));
 
         writer.writeUint8(255);
@@ -125,7 +125,7 @@ List<int> calcVarInt(int? length) {
 
     if (length < 0xFFFFFFFF) return HEX.decode("FE" + length.toRadixString(16));
 
-    if (length < 0xFFFFFFFFFFFFFFFF) return HEX.decode("FF" + length.toRadixString(16));
+    if (BigInt.parse("0xFFFFFFFFFFFFFFFF").compareTo(BigInt.from(length)) == -1) return HEX.decode("FF" + length.toRadixString(16));
 
     return Uint8List(0);
 }


### PR DESCRIPTION
Hello there! 
First of all, great work on the library, it's extremely useful and made my last couple of weeks way easier.  

Earlier this year Google added Web support to its Flutter framework, what made mobile, desktop and browser based app development from the shared Dart codebase an easy and straightforward task. Unfortunately `dart2js` compiler does't know how to handle numbers that are larger then JS `Number.MAX_SAFE_INTEGER` (9007199254740991) and it throws on the build time:

![Screenshot 2022-07-08 at 02 40 14](https://user-images.githubusercontent.com/347657/177895136-179c8cc0-3d37-419d-be1b-eb007027d497.png)

Forcing Dart to use a BigInt comparison here solves the issue. 

Is this something you would consider adding to the next release? It would make our lives way easier. Thanks a lot.