### PR TITLE
Changed default Transaction nVersion to 2

### DIFF
--- a/lib/src/transaction/transaction.dart
+++ b/lib/src/transaction/transaction.dart
@@ -73,7 +73,7 @@ enum TransactionOption {
 /// `4 bytes` - A time (Unix epoch time) or block number. See the [nLockTime] parsing rules.
 ///
 class Transaction{
-    int _version = 1;
+    int _version = 2;
     int _nLockTime = 0;
     final List<TransactionInput> _txnInputs = [];  //this transaction's inputs
     final List<TransactionOutput> _txnOutputs = []; //this transaction's outputs

--- a/test/script/interpreter_test.dart
+++ b/test/script/interpreter_test.dart
@@ -428,6 +428,7 @@ void main() {
 
         var hashbuf = List<int>.filled(32, 0);
         Transaction credtx = new Transaction();
+        credtx.version = 1;
         var coinbaseUnlockBuilder = DefaultUnlockBuilder();
         coinbaseUnlockBuilder.fromScript(SVScript.fromString('OP_0 OP_0'));
         TransactionInput txCredInput = TransactionInput(
@@ -455,6 +456,7 @@ void main() {
         var defaultUnlockBuilder = DefaultUnlockBuilder();
         defaultUnlockBuilder.fromScript(scriptSig);
         var spendtx = Transaction();
+        spendtx.version = 1;
         var txSpendInput = TransactionInput(
             prevTxId,
             0,

--- a/test/transaction/multisig_builder_test.dart
+++ b/test/transaction/multisig_builder_test.dart
@@ -80,6 +80,7 @@ void main() {
           .spendTo(toAddress, BigInt.from(500000), scriptBuilder: P2PKHLockBuilder(toAddress))
           .sendChangeTo(changeAddress, scriptBuilder: P2PKHLockBuilder(changeAddress));
 
+      transaction.version = 1;
       transaction.withFeePerKb(100000);
 
       transaction.signInput(0, private1);

--- a/test/transaction/transaction_test.dart
+++ b/test/transaction/transaction_test.dart
@@ -209,6 +209,7 @@ main() {
 
     test('serializes an empty transaction', () {
         var transaction = new Transaction();
+        transaction.version = 1;
         expect(transaction.uncheckedSerialize(), equals(txEmptyHex));
     });
 
@@ -235,6 +236,7 @@ main() {
                     transaction.spendTo(Address(elem[0]), BigInt.from(elem[1]), scriptBuilder: P2PKHLockBuilder(addr));
                 };
 
+                transaction.version = 1;
                 transaction.withFeePerKb(100000);
                 transaction.signInput(0, privKey, sighashType: item['sign'][1]);
 
@@ -1073,7 +1075,8 @@ main() {
           .spendFromMap(from3, scriptBuilder: P2PKHUnlockBuilder(privateKey.publicKey))
           .spendFromMap(from2, scriptBuilder: P2PKHUnlockBuilder(privateKey.publicKey))
           .spendFromMap(from1, scriptBuilder: P2PKHUnlockBuilder(privateKey.publicKey));
-      
+
+      tx.version = 1;
       tx.signInput(0, privateKey);
       tx.signInput(1, privateKey);
       tx.signInput(2, privateKey);


### PR DESCRIPTION
- Changed the default Transaction version to 2. This is the default transaction version for BitcoinSV now. The test fixtures still reference older transaction versions.