### PR TITLE
Dart Version bump to 3.x

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,14 +5,14 @@ homepage: https://github.com/twostack/cli-example
 author: Stephan M. February <stephan@werkswinkel.com>
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  hex: ^0.1.2
+  hex: 0.2.0
   collection: ^1.14.11
-  sprintf: ^4.0.2
-  http: ^0.12.0+2
-  dartsv: ^0.4.2
+  sprintf: ^6.0.0
+  http: ^0.13.3
+  dartsv: ^1.0.0
   bip39: ^1.0.3
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,18 +4,17 @@ version: 1.0.1
 homepage: https://github.com/twostack/dartsv
 
 environment:
-  sdk: '>=2.12.2 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
   hex: ^0.2.0
-  resource_portable: ^3.0.0
-  pointycastle: ^3.3.4
-  collection: ^1.15.0
-  sprintf: ^6.0.0
+  resource_portable: ^3.1.0
+  pointycastle: ^3.7.0
+  sprintf: ^7.0.0
   unorm_dart: ^0.2.0
   buffer: ^1.1.1
 
 dev_dependencies:
-  lints : ^1.0.1
+  lints : ^2.1.1
   test: ^1.18.2
   mockito: ^5.0.16


### PR DESCRIPTION
- Upgraded supported dart version to 3.x
- Updated older library minimum version requirements