### PR TITLE
RC2 Release Prep

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -15,7 +15,7 @@ jobs:
       image:  dart:latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: pub get
     - name: Run tests

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image:  dart:3.1-sdk
+      image:  dart:latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,12 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image:  dart:latest
-
     steps:
     - uses: actions/checkout@v3
+    - uses: dart-lang/setup-dart@v1
     - name: Install dependencies
-      run: pub get
+      run: dart pub get
     - name: Run tests
-      run: pub run test
+      run: dart test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image:  google/dart:latest
+      image:  dart:3.1-sdk
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-rc2
+- Large data Transaction fixes. There was a bug which prevented the crafting of
+  large data transactions, i.e transactions with outputs that have PUSHDATA operations
+  that pushed more than 65k bytes onto the stack. 
+
 ## 2.0.0-rc1
 
 Version 2.x is a major refactor of the internals. 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2020 Stephan M. February <stephan@werkswinkel.com>
+Copyright (c) 2019-2023 Stephan M. February <stephan@werkswinkel.com>
 
 Copyright (c) 2018-2019 Yours Inc.
 

--- a/lib/src/coin.dart
+++ b/lib/src/coin.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:dartsv/src/transaction/preconditions.dart';
 import 'package:decimal/decimal.dart';
 
 /**

--- a/lib/src/transaction/transaction.dart
+++ b/lib/src/transaction/transaction.dart
@@ -77,7 +77,6 @@ class Transaction {
   final ECDSASigner _dsaSigner = ECDSASigner(null, HMac(_sha256Digest, 64));
   final ECDomainParameters _domainParams = ECDomainParameters('secp256k1');
 
-  BigInt? _fee;
   bool _changeScriptFlag = false;
 
   var CURRENT_VERSION = 1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartsv
 description: Dart Library for interacting with the Bitcoin network. This library is especially well-suited for use in developing Flutter applications.
-version: 2.0.0-rc1
+version: 2.0.0-rc2
 homepage: https://github.com/twostack/dartsv
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0-rc2
 homepage: https://github.com/twostack/dartsv
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   hex: ^0.2.0


### PR DESCRIPTION
-  Double-checked spendability of large output transactions after some minor tweaks.
-   Set absolute minimum SDk version to 2.17 to take advantage of enhanced enums while having max compatibility