### PR TITLE
Bugfix: Uint64 error when using with Flutter Web

### DIFF
--- a/lib/src/encoding/utils.dart
+++ b/lib/src/encoding/utils.dart
@@ -176,6 +176,8 @@ BigInt readVarInt(Uint8List buffer) {
 Uint8List encodeBigIntSV(BigInt number) {
   int size = (number.bitLength + 7) >> 3;
 
+  if (size == 0) size = 8; //always padd to 64 bits if zero
+
   var result = Uint8List(size);
   for (int i = 0; i < size; i++) {
     result[size - i - 1] = (number & _byteMask).toInt();

--- a/lib/src/sighash.dart
+++ b/lib/src/sighash.dart
@@ -324,7 +324,7 @@ class Sighash {
         writer.write(subscript.buffer);
 
         // value of the output spent by this input (8-byte little endian)
-        writer.writeUint64(satoshis.toInt(), Endian.little);
+        writer.write(encodeBigIntSV(satoshis));
 
         // nSequence of the input (4-byte little endian)
         var sequenceNumber = input.sequenceNumber;

--- a/lib/src/transaction/transaction_output.dart
+++ b/lib/src/transaction/transaction_output.dart
@@ -37,7 +37,8 @@ class TransactionOutput {
     /// being used.
     TransactionOutput.fromReader(ByteDataReader reader) {
 
-        this.satoshis = BigInt.from(reader.readUint64(Endian.little));
+        var buffer = reader.read(8);
+        this.satoshis = castToBigInt(buffer, false, nMaxNumSize: 8);
         var size = readVarIntNum(reader);
         if (size != 0) {
             _script = SVScript.fromBuffer(reader.read(size, copy: true));


### PR DESCRIPTION
- Removed the writeUint64 and readUint64 calls since dart2js can't natively represent 64bit ints in JS.