### PR TITLE
BugFix: Uint64 conversion errors with Dart2JS / Flutter Web

### DIFF
--- a/lib/src/sighash.dart
+++ b/lib/src/sighash.dart
@@ -318,7 +318,7 @@ class Sighash {
         writer.write(subscript.buffer);
 
         // value of the output spent by this input (8-byte little endian)
-        writer.writeUint64(satoshis.toInt(), Endian.little);
+        writer.write(encodeBigIntLE(satoshis));
 
         // nSequence of the input (4-byte little endian)
         var sequenceNumber = input.sequenceNumber;

--- a/lib/src/transaction/transaction_output.dart
+++ b/lib/src/transaction/transaction_output.dart
@@ -47,7 +47,9 @@ class TransactionOutput {
 
         _scriptBuilder = scriptBuilder ??= DefaultLockBuilder();
 
-        this.satoshis = BigInt.from(reader.readUint64(Endian.little));
+        var buffer = reader.read(8);
+        this.satoshis = castToBigInt(buffer, false, nMaxNumSize: 8);
+
         var size = readVarIntNum(reader);
         if (size != 0) {
             var script = SVScript.fromBuffer(reader.read(size, copy: true));
@@ -175,20 +177,6 @@ class TransactionOutput {
 
     /// Returns the current instance of LockingScriptBuilder in use by this instance
     LockingScriptBuilder get scriptBuilder => _scriptBuilder!;
-
-//FIXME: Swing back to this leaner implementation based on ByteDataWriter()
-//    List<int> serialize2(){
-//        var writer = ByteDataWriter();
-//
-//        writer.writeUint64(this._satoshis.toInt(), Endian.little);
-//
-//        var scriptHex = HEX.decode(this.script.toHex());
-//        writer.write(varIntWriter(scriptHex.length).toList(), copy: true);
-//
-//        writer.write(this.script.buffer);
-//
-//        return writer.toBytes().toList();
-//    }
 
 
 }


### PR DESCRIPTION
- Removed all direct reading and writing of Uint64 types. Dart2JS can't handle the size.