### PR TITLE
Bugfix: Override of network type fails when deriving address

### DIFF
--- a/lib/src/privatekey.dart
+++ b/lib/src/privatekey.dart
@@ -248,8 +248,7 @@ class SVPrivateKey {
     /// Convenience method that jumps through the hoops of generating and [Address] from this
     /// Private Key's corresponding [SVPublicKey].
     Address toAddress({NetworkType networkType = NetworkType.MAIN}) {
-        //FIXME: set network type to default parameter unless explicitly specified ?
-        return _svPublicKey!.toAddress(_networkType);
+        return _svPublicKey!.toAddress(networkType);
     }
 
     Uint8List _seed() {

--- a/test/privatekey_test.dart
+++ b/test/privatekey_test.dart
@@ -116,8 +116,23 @@ main(){
 
     test('should output this known testnet address correctly', () {
         var privkey = SVPrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
-        var address = privkey.toAddress();
+        var address = privkey.toAddress(networkType: NetworkType.TEST);
         expect(address.toString(), equals('mtX8nPZZdJ8d3QNLRJ1oJTiEi26Sj6LQXS'));
+    });
+
+    test('should honor the network type setting for toAddress() ', () {
+
+        //take a wif from mainnet
+        SVPrivateKey privateKey = SVPrivateKey.fromWIF('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
+        Address testnetAddress = privateKey.toAddress(networkType: NetworkType.TEST);
+
+        //expect a testnet address
+        expect(testnetAddress.toString(), equals('mpcsB4yVbWGGDLsx5R3Gi8uLvwDJDLAVcv'));
+
+        //expect a mainnet address
+        Address mainnetAddress= privateKey.toAddress(networkType: NetworkType.MAIN);
+        expect(mainnetAddress.toString(), equals('1A6ut1tWnUq1SEQLMr4ttDh24wcbJ5o9TT'));
+
     });
 
     test('should parse this compressed testnet address correctly', () {


### PR DESCRIPTION
- It should be possible to override the internal network type of a private key when deriving an address from it.